### PR TITLE
Fix filters with different primary keys

### DIFF
--- a/lib/kaffy_web/templates/layout/bare.html.eex
+++ b/lib/kaffy_web/templates/layout/bare.html.eex
@@ -20,10 +20,10 @@
       <nav class="navbar default-layout-navbar col-lg-12 col-12 p-0 fixed-top d-flex flex-row">
         <div class="text-center navbar-brand-wrapper d-flex align-items-center justify-content-center">
           <%= link to: Kaffy.Utils.router().kaffy_home_path(@conn, :index), class: "navbar-brand brand-logo" do %>
-            <img src="/kaffy/assets/images/logo.png" alt="logo" />
+            <img src="<%= Kaffy.Utils.logo(@conn) %>" alt="logo" />
           <% end %>
           <%= link to: Kaffy.Utils.router().kaffy_home_path(@conn, :index), class: "navbar-brand brand-logo-mini" do %>
-            <img src="/kaffy/assets/images/logo-mini.png" alt="logo" />
+            <img src="<%= Kaffy.Utils.logo_mini(@conn) %>" alt="logo" />
           <% end %>
         </div>
         <div class="navbar-menu-wrapper d-flex align-items-stretch">

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -85,11 +85,12 @@
         <% end %>
     <% end %>
   <% end %>
+  <% [{order_way, order_field}] = Kaffy.ResourceQuery.get_ordering(@my_resource, @params) %>
   <input id="kaffy-filter-search" type="hidden" name="search" value="<%= Map.get(@params, "search", "") %>" />
   <input id="kaffy-filter-page" type="hidden" name="page" value="<%= Map.get(@params, "page", "1") %>" />
   <input id="kaffy-filter-limit" type="hidden" name="limit" value="<%= Map.get(@params, "limit", "100") %>" />
-  <input id="kaffy-order-field" type="hidden" name="<%= to_string(:_of) %>" value="<%= Map.get(@params, "_of", "id") %>" />
-  <input id="kaffy-order-way" type="hidden" name="<%= to_string(:_ow) %>" value="<%= Map.get(@params, "_ow", "desc") %>" />
+  <input id="kaffy-order-field" type="hidden" name="<%= to_string(:_of) %>" value="<%= Map.get(@params, "_of", order_field) %>" />
+  <input id="kaffy-order-way" type="hidden" name="<%= to_string(:_ow) %>" value="<%= Map.get(@params, "_ow", order_way) %>" />
 </form>
 
 


### PR DESCRIPTION
When filtering using a variable from a predefined list, the elements returned are ordered by ID. If the table does not contain ʻID` as the primary key, PostgreSQL attempts to obtain the ID field and break it.


![image](https://user-images.githubusercontent.com/26944512/96520721-0a9cf000-1246-11eb-9e9b-313e4a568252.png)


The filter in the `VALUE` column is a selection entry with a tuple following this example: `{description, value_id}`.